### PR TITLE
Rag Rating Failing for public bodies

### DIFF
--- a/src/SFA.DAS.Data.Database/Views/DAS_Employer_Registrations.sql
+++ b/src/SFA.DAS.Data.Database/Views/DAS_Employer_Registrations.sql
@@ -42,7 +42,7 @@ AS
                            (CASE WHEN [ELE].[Code] IS NULL OR [ELE].[Code] = '0' THEN 'Red'
                                                 WHEN ISNUMERIC(LEFT([ELE].[Code],2)) <> 1 THEN 'Amber' ELSE 'Green' END)
                      -- Public Sector always set to Amber
-                     WHEN [ELE].[Code] = 'Public Bodies' THEN 'Amber'             
+                     WHEN [ELE].[Source] = 'Public Bodies' THEN 'Amber'             
                       ELSE 'ERROR'
             END AS [LegalEntityRAGRating]
      --,  CASE WHEN [ELE].[Source] IN ('Charities','Companies House') THEN


### PR DESCRIPTION
Issues was that [ELE].[Code]  used rather than [ELE].[Source] and was forcing the case statement to the default of "ERROR"