### PR TITLE
Make indentation more consistent on DAS_Commitments view

### DIFF
--- a/src/SFA.DAS.Data.Database/Views/DAS_Commitments.sql
+++ b/src/SFA.DAS.Data.Database/Views/DAS_Commitments.sql
@@ -1,16 +1,16 @@
 CREATE VIEW [Data_Pub].[DAS_Commitments]
 AS
-	SELECT [C].[ID]
+  SELECT [C].[ID]
           , CAST([C].[CommitmentID] AS BIGINT) AS EventID
           , CAST([C].[PaymentStatus] AS VARCHAR(50)) AS PaymentStatus
           , CAST([C].[ApprenticeshipID]AS BIGINT) AS CommitmentID
           , CAST([c].[AgreementStatus] AS VARCHAR(50)) AS AgreementStatus
           , CASE WHEN ISNUMERIC([C].[ProviderID])=1 then CAST([C].[ProviderID] AS BIGINT) ELSE -2 END AS [UKPRN]
-		, CASE WHEN ISNUMERIC([C].[LearnerID])=1 then CAST([C].[LearnerID] AS BIGINT) ELSE -2 END AS [ULN]  
-		, CAST([C].[ProviderID] AS VARCHAR(255)) AS ProviderID 
-          , CAST([C].[LearnerID] AS VARCHAR(255)) AS LearnerID           
-	  , CAST([C].[EmployerAccountID] AS VARCHAR(255)) AS EmployerAccountID
-	  , CAST(EA.[DasAccountId] AS VARCHAR(100)) AS DasAccountId
+          , CASE WHEN ISNUMERIC([C].[LearnerID])=1 then CAST([C].[LearnerID] AS BIGINT) ELSE -2 END AS [ULN]
+          , CAST([C].[ProviderID] AS VARCHAR(255)) AS ProviderID
+          , CAST([C].[LearnerID] AS VARCHAR(255)) AS LearnerID
+          , CAST([C].[EmployerAccountID] AS VARCHAR(255)) AS EmployerAccountID
+          , CAST(EA.[DasAccountId] AS VARCHAR(100)) AS DasAccountId
           , CAST([C].[TrainingTypeID] AS VARCHAR(255)) AS TrainingTypeID
           , CAST([C].[TrainingID] AS VARCHAR(255)) AS TrainingID
           , CASE
@@ -41,35 +41,39 @@ AS
           , CAST([C].[UpdateDateTime] AS DATE) AS [UpdateDate]
             -- Flag to say if latest record from subquery, Using Coalesce to set null value to 0
           , CAST(COALESCE([LC].[Flag_Latest], 0) AS INT) AS [Flag_Latest]
-		, CAST(C.[LegalEntityCode] AS VARCHAR(50)) AS LegalEntityCode
-		, CAST(C.[LegalEntityName] AS VARCHAR(100)) AS LegalEntityName
-		, CAST(C.[LegalEntityOrganisationType] AS VARCHAR(20)) AS LegalEntitySource
-		, CAST(COALESCE(ELE.[DasLegalEntityId],-1) AS BIGINT) AS [DasLegalEntityId]
-		, CAST(C.DateOfBirth AS DATE) AS DateOfBirth
-		, CASE WHEN C.DateOfBirth IS NULL THEN -1
-                        WHEN DATEPART(M,C.DateOfBirth) > DATEPART(M,C.TrainingStartDate) OR (DATEPART(M,C.DateOfBirth) = DATEPART(M,C.TrainingStartDate) AND DATEPART(DD,C.DateOfBirth) > DATEPART(DD,C.TrainingStartDate)) THEN DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate) -1
-                        ELSE DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate)
-                   END AS CommitmentAgeAtStart
-		, CASE WHEN CASE WHEN C.DateOfBirth IS NULL THEN -1
-                        WHEN DATEPART(M,C.DateOfBirth) > DATEPART(M,C.TrainingStartDate) OR (DATEPART(M,C.DateOfBirth) = DATEPART(M,C.TrainingStartDate) AND DATEPART(DD,C.DateOfBirth) > DATEPART(DD,C.TrainingStartDate)) THEN DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate) -1
-                        ELSE DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate)
-                   END BETWEEN 0 AND 18 THEN '16-18'
-			    ELSE '19+' END AS CommitmentAgeAtStartBand
-		, CASE WHEN PP.TotalAmount > 0  THEN 'Yes' ELSE 'No' END AS RealisedCommitment
-		--, CASE WHEN C.AgreementStatus = 'BothAgreed' THEN 'Yes'
-		--	 ELSE 'No'END AS FullyAgreedCommitment
-		, CASE WHEN [C].[TrainingStartDate] BETWEEN DATEADD(mm, DATEDIFF(mm, 0, GETDATE()), 0) AND DATEADD (dd, -1, DATEADD(mm, DATEDIFF(mm, 0, GETDATE()) + 1, 0)) THEN 'Yes'
-				ELSE 'No' END AS StartDateInCurrentMonth
-		-- , DATEADD(mm, DATEDIFF(mm, 0, GETDATE()), 0) AS [Start day of current month]  
-		-- , DATEADD (dd, -1, DATEADD(mm, DATEDIFF(mm, 0, GETDATE()) + 1, 0)) AS [Last day of current month]
-		, CASE	 
-			 WHEN [AgreementStatus] = 'NotAgreed'      THEN 1
-			 WHEN [AgreementStatus] = 'EmployerAgreed' THEN 2
-			 WHEN [AgreementStatus] = 'ProviderAgreed' THEN 3
-			 WHEN  [AgreementStatus] = 'BothAgreed'	   THEN 4
-	   		 ELSE 9 END AS [AgreementStatus_SortOrder]
-	  , EAA.AccountName AS DASAccountName
-	FROM
+          , CAST(C.[LegalEntityCode] AS VARCHAR(50)) AS LegalEntityCode
+          , CAST(C.[LegalEntityName] AS VARCHAR(100)) AS LegalEntityName
+          , CAST(C.[LegalEntityOrganisationType] AS VARCHAR(20)) AS LegalEntitySource
+          , CAST(COALESCE(ELE.[DasLegalEntityId],-1) AS BIGINT) AS [DasLegalEntityId]
+          , CAST(C.DateOfBirth AS DATE) AS DateOfBirth
+          , CASE
+                WHEN C.DateOfBirth IS NULL THEN -1
+                WHEN DATEPART(M,C.DateOfBirth) > DATEPART(M,C.TrainingStartDate) OR (DATEPART(M,C.DateOfBirth) = DATEPART(M,C.TrainingStartDate) AND DATEPART(DD,C.DateOfBirth) > DATEPART(DD,C.TrainingStartDate)) THEN DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate) -1
+                ELSE DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate)
+            END AS CommitmentAgeAtStart
+          , CASE
+                WHEN CASE WHEN C.DateOfBirth IS NULL THEN -1
+                WHEN DATEPART(M,C.DateOfBirth) > DATEPART(M,C.TrainingStartDate) OR (DATEPART(M,C.DateOfBirth) = DATEPART(M,C.TrainingStartDate) AND DATEPART(DD,C.DateOfBirth) > DATEPART(DD,C.TrainingStartDate)) THEN DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate) -1
+                ELSE DATEDIFF(YEAR,C.DateOfBirth,C.TrainingStartDate)
+                END BETWEEN 0 AND 18 THEN '16-18'
+                ELSE '19+'
+            END AS CommitmentAgeAtStartBand
+          , CASE WHEN PP.TotalAmount > 0  THEN 'Yes' ELSE 'No' END AS RealisedCommitment
+        --, CASE WHEN C.AgreementStatus = 'BothAgreed' THEN 'Yes'
+        --  ELSE 'No'END AS FullyAgreedCommitment
+          , CASE WHEN [C].[TrainingStartDate] BETWEEN DATEADD(mm, DATEDIFF(mm, 0, GETDATE()), 0) AND DATEADD (dd, -1, DATEADD(mm, DATEDIFF(mm, 0, GETDATE()) + 1, 0)) THEN 'Yes'
+            ELSE 'No' END AS StartDateInCurrentMonth
+       -- , DATEADD(mm, DATEDIFF(mm, 0, GETDATE()), 0) AS [Start day of current month]
+       -- , DATEADD (dd, -1, DATEADD(mm, DATEDIFF(mm, 0, GETDATE()) + 1, 0)) AS [Last day of current month]
+          , CASE
+                WHEN [AgreementStatus] = 'NotAgreed'      THEN 1
+                WHEN [AgreementStatus] = 'EmployerAgreed' THEN 2
+                WHEN [AgreementStatus] = 'ProviderAgreed' THEN 3
+                WHEN [AgreementStatus] = 'BothAgreed'     THEN 4
+                ELSE 9
+            END AS [AgreementStatus_SortOrder]
+          , EAA.AccountName AS DASAccountName
+  FROM
         Data_Load.DAS_Commitments AS C
     -- To get latest record
         LEFT JOIN
@@ -77,85 +81,85 @@ AS
          SELECT [C].[ApprenticeshipId]
               , MAX([C].[UpdateDateTime]) AS [Max_UpdatedDateTime]
               , MAX([C].ID)  AS Max_ID
-		    , 1 AS [Flag_Latest]
+              , 1 AS [Flag_Latest]
          FROM
             Data_Load.DAS_Commitments AS C
          GROUP BY [C].[ApprenticeshipId]
      ) AS LC ON LC.ApprenticeshipId = C.ApprenticeshipId
                 AND LC.Max_ID = C.ID
-			 AND LC.Max_UpdatedDateTime = C.UpdateDateTime
-	-- Join to Accounts to get the Hashed DAS Acccount ID
-	LEFT JOIN  (SELECT DISTINCT EA.[DasAccountId], EA.AccountID
-				FROM [Data_Load].[DAS_Employer_Accounts] AS EA) AS EA ON EA.AccountID = [C].[EmployerAccountID]
-	---- Join Legal Entity to get Legal_Entity_ID
-    LEFT JOIN (SELECT 
-    			    DISTINCT
-    					  ELE.DasAccountId
-    					, ELE.[LegalEntityNumber]
-    					, ELE.[LegalEntityName]
-    					,REPLACE(ELE.[LegalEntitySource],' ','') AS [LegalEntitySource] 
-    					,ELE.[DasLegalEntityId]
-    		 FROM 
-    			Data_Pub.DAS_Employer_LegalEntities AS ELE
-    		 INNER JOIN  (
-			SELECT		
-						ELE.[DasAccountId]
-					,	ELE.[DasLegalEntityId]
-					,	MAX(ELE.[UpdateDateTime]) AS Max_UpdatedDateTime
-					,	1 AS Flag_Latest 
-			FROM [Data_Load].[DAS_Employer_LegalEntities] AS ELE
-			GROUP BY 
-						ELE.[DasAccountId]
-					,	ELE.[DasLegalEntityId]
-			) AS LELE ON ELE.DasAccountId = LELE.DasAccountId
-					AND ELE.DasLegalEntityId = LELE.DasLegalEntityId
-					AND ELE.[UpdateDateTime] = LELE.Max_UpdatedDateTime) AS ELE ON C.LegalEntityOrganisationType = ELE.[LegalEntitySource]
-    											AND  C.[LegalEntityCode] = ELE.[LegalEntityNumber]
-    											AND C.[LegalEntityName] = ELE.LegalEntityName 
-    											AND EA.DasAccountId = ELE.DasAccountId
-												
-    LEFT JOIN (SELECT P.ApprenticeshipId AS CommitmentId
-    			    , SUM(P.Amount) AS TotalAmount
-    	      FROM Data_Load.DAS_Payments AS P 
-		 INNER JOIN  
+       AND LC.Max_UpdatedDateTime = C.UpdateDateTime
+  -- Join to Accounts to get the Hashed DAS Acccount ID
+  LEFT JOIN  (SELECT DISTINCT EA.[DasAccountId], EA.AccountID
+        FROM [Data_Load].[DAS_Employer_Accounts] AS EA) AS EA ON EA.AccountID = [C].[EmployerAccountID]
+  ---- Join Legal Entity to get Legal_Entity_ID
+  LEFT JOIN (SELECT
+              DISTINCT
+                ELE.DasAccountId
+              , ELE.[LegalEntityNumber]
+              , ELE.[LegalEntityName]
+              ,REPLACE(ELE.[LegalEntitySource],' ','') AS [LegalEntitySource]
+              ,ELE.[DasLegalEntityId]
+         FROM
+          Data_Pub.DAS_Employer_LegalEntities AS ELE
+         INNER JOIN  (
+      SELECT
+            ELE.[DasAccountId]
+          ,	ELE.[DasLegalEntityId]
+          ,	MAX(ELE.[UpdateDateTime]) AS Max_UpdatedDateTime
+          ,	1 AS Flag_Latest
+      FROM [Data_Load].[DAS_Employer_LegalEntities] AS ELE
+      GROUP BY
+            ELE.[DasAccountId]
+          ,	ELE.[DasLegalEntityId]
+      ) AS LELE ON ELE.DasAccountId = LELE.DasAccountId
+          AND ELE.DasLegalEntityId = LELE.DasLegalEntityId
+          AND ELE.[UpdateDateTime] = LELE.Max_UpdatedDateTime) AS ELE ON C.LegalEntityOrganisationType = ELE.[LegalEntitySource]
+                          AND  C.[LegalEntityCode] = ELE.[LegalEntityNumber]
+                          AND C.[LegalEntityName] = ELE.LegalEntityName
+                          AND EA.DasAccountId = ELE.DasAccountId
+
+  LEFT JOIN (SELECT P.ApprenticeshipId AS CommitmentId
+              , SUM(P.Amount) AS TotalAmount
+            FROM Data_Load.DAS_Payments AS P
+     INNER JOIN
    --Looking to get the max Collection information for the delivery Period, Commitment ID and Employer Account ID
         (
          SELECT [P].[EmployerAccountID]
-		    , P.ApprenticeshipId 
-		    , P.DeliveryMonth
-		    , P.DeliveryYear
+        , P.ApprenticeshipId
+        , P.DeliveryMonth
+        , P.DeliveryYear
               , MAX(CAST(P.CollectionYear AS VARCHAR(255)) + '-'+CAST(P.CollectionMonth AS VARCHAR(255))) AS [Max_CollectionPeriod]
-		    , 1 AS [Flag_Latest]
+        , 1 AS [Flag_Latest]
          FROM
             [Data_Load].[DAS_Payments] AS P
-	    GROUP BY 
-			 P.EmployerAccountID
-		    , P.ApprenticeshipId
-		    , P.DeliveryMonth
-		    , P.DeliveryYear
+      GROUP BY
+       P.EmployerAccountID
+        , P.ApprenticeshipId
+        , P.DeliveryMonth
+        , P.DeliveryYear
      ) AS LP ON LP.EmployerAccountID = P.EmployerAccountID
-			 AND LP.ApprenticeshipId = P.ApprenticeshipId
-			 AND LP.DeliveryMonth = P.DeliveryMonth
-			 AND LP.DeliveryYear = P.DeliveryYear
-			 AND LP.Max_CollectionPeriod = (CAST(P.CollectionYear AS VARCHAR(255)) + '-'+CAST(P.CollectionMonth AS VARCHAR(255)))
-    		 GROUP BY P.ApprenticeshipId) AS PP ON C.ApprenticeshipID = PP.CommitmentID
+       AND LP.ApprenticeshipId = P.ApprenticeshipId
+       AND LP.DeliveryMonth = P.DeliveryMonth
+       AND LP.DeliveryYear = P.DeliveryYear
+       AND LP.Max_CollectionPeriod = (CAST(P.CollectionYear AS VARCHAR(255)) + '-'+CAST(P.CollectionMonth AS VARCHAR(255)))
+         GROUP BY P.ApprenticeshipId) AS PP ON C.ApprenticeshipID = PP.CommitmentID
     -- DAS Account Name
-    LEFT JOIN (SELECT 
-				A.DASAccountID
-				,A.AccountID
-				,A.AccountName
-			 FROM [Data_Load].[DAS_Employer_Accounts] AS A
+  LEFT JOIN (SELECT
+        A.DASAccountID
+        ,A.AccountID
+        ,A.AccountName
+       FROM [Data_Load].[DAS_Employer_Accounts] AS A
 
-			 INNER JOIN (
-						 SELECT		
-									 EA.[DasAccountId]
-								 ,	MAX(EA.[UpdateDateTime]) AS Max_UpdatedDateTime
-								 ,	1 AS Flag_Latest 
-						 FROM [Data_Load].[DAS_Employer_Accounts] AS EA
-						 GROUP BY 
-						EA.[DasAccountId]
-			) AS LEA ON A.DasAccountId = LEA.DasAccountId 
-					AND lea.Max_UpdatedDateTime = A.[UpdateDateTime]) AS EAA ON EAA.AccountID = [C].[EmployerAccountID]
-	
-	;
+       INNER JOIN (
+             SELECT
+                   EA.[DasAccountId]
+                 ,	MAX(EA.[UpdateDateTime]) AS Max_UpdatedDateTime
+                 ,	1 AS Flag_Latest
+             FROM [Data_Load].[DAS_Employer_Accounts] AS EA
+             GROUP BY
+            EA.[DasAccountId]
+      ) AS LEA ON A.DasAccountId = LEA.DasAccountId
+          AND lea.Max_UpdatedDateTime = A.[UpdateDateTime]) AS EAA ON EAA.AccountID = [C].[EmployerAccountID]
+
+  ;
 GO


### PR DESCRIPTION
All tabs have been converted to spaces for consistency.
Best reviewed with "git diff -w" which ignores all the whitespace changes:

https://github.com/SkillsFundingAgency/das-data/compare/make-indentation-more-consistent-on-commitments-view?expand=1&w=1