### PR TITLE
Add sort order to levy balance view

### DIFF
--- a/src/SFA.DAS.Data.Database/Views/LevyBalance.sql
+++ b/src/SFA.DAS.Data.Database/Views/LevyBalance.sql
@@ -2,73 +2,89 @@ CREATE VIEW Reporting.LevyBalance
        AS
        SELECT
               [PayrollMonthShortNameYear] AS CalendarMonthShortNameYear
-              , PayrollMonth
-              , Payrollyear = cast (left(Payrollyear,2) AS INT)
-            , 'LevyIn' AS ValueType
+            , PayrollMonth
+            , Payrollyear = cast (left(Payrollyear,2) AS INT)
+            , 'Levy funds' AS ValueType
             , SUM([LevyDeclaredInMonthWithEnglishFractionApplied]) AS Value
+            , ValueTypeSort = 1
          FROM [Data_Pub].[DAS_LevyDeclarations]
-       WHERE Flag_latest = 1
-       GROUP BY
-              [PayrollMonthShortNameYear]  ,PayrollMonth,
-                cast (left(Payrollyear,2) AS INT)
-       UNION ALL
+        WHERE Flag_latest = 1
+     GROUP BY
+              [PayrollMonthShortNameYear]
+            , PayrollMonth
+            , CAST(left(Payrollyear,2) AS INT)
+UNION ALL
        SELECT
               [PayrollMonthShortNameYear] AS CalendarMonthShortNameYear
-              , PayrollMonth
-              , Payrollyear = CAST (left(Payrollyear,2) AS INT)
-            , 'LevyTopUp' AS ValueType
+            , PayrollMonth
+            , Payrollyear = CAST (left(Payrollyear,2) AS INT)
+            , 'Levy top-up funds' AS ValueType
             , SUM([TopupAmount]) AS Value
+            , ValueTypeSort = 2
          FROM [Data_Pub].[DAS_LevyDeclarations]
-       WHERE Flag_latest = 1
-       GROUP BY
-              [PayrollMonthShortNameYear], PayrollMonth
-              , CAST (left(Payrollyear,2) AS INT)
-       UNION ALL
+        WHERE Flag_latest = 1
+     GROUP BY
+              [PayrollMonthShortNameYear]
+            , PayrollMonth
+            , CAST(left(Payrollyear,2) AS INT)
+UNION ALL
        SELECT
               [DeliveryMonthShortNameYear] AS CalendarMonthShortNameYear
             , DeliveryMonth
-              , DeliveryYear =CAST(Right(DeliveryYear,2)AS INT)
-              , 'Levy Payment' AS ValueType
+            , DeliveryYear =CAST(Right(DeliveryYear,2)AS INT)
+            , 'Levy Payment' AS ValueType
             , SUM([Amount]) AS Value
+            , ValueTypeSort = 3
          FROM [Data_Pub].[DAS_Payments]
-       WHERE Flag_latest = 1 and FundingSource = 'Levy'
-       GROUP BY
-              [DeliveryMonthShortNameYear], DeliveryMonth
-              , CAST(Right(DeliveryYear,2)AS INT)
-       UNION ALL
+        WHERE Flag_latest = 1
+          AND FundingSource = 'Levy'
+     GROUP BY
+              [DeliveryMonthShortNameYear]
+            , DeliveryMonth
+            , CAST(Right(DeliveryYear,2)AS INT)
+UNION ALL
        SELECT
               [DeliveryMonthShortNameYear] AS CalendarMonthShortNameYear
               , DeliveryMonth
               , DeliveryYear = CAST(Right(DeliveryYear,2)AS INT)
-            , 'FullyFundedSfa' AS ValueType
+            , 'Fully funded SFA' AS ValueType
             , SUM([Amount]) AS Value
+              ,ValueTypeSort = 6
          FROM [Data_Pub].[DAS_Payments]
-       WHERE Flag_latest = 1 and FundingSource = 'FullyFundedSfa'
-       GROUP BY
-              [DeliveryMonthShortNameYear], DeliveryMonth
-              , CAST(Right(DeliveryYear,2)AS INT)
+        WHERE Flag_latest = 1
+          AND FundingSource = 'FullyFundedSfa'
+     GROUP BY
+              [DeliveryMonthShortNameYear]
+            , DeliveryMonth
+            , CAST(Right(DeliveryYear,2)AS INT)
 UNION ALL
-SELECT
+       SELECT
               [DeliveryMonthShortNameYear] AS CalendarMonthShortNameYear
-              , DeliveryMonth
-              , DeliveryYear = CAST(Right(DeliveryYear,2)AS INT)
-            , 'CoInvestedEmployer' AS ValueType
+            , DeliveryMonth
+            , DeliveryYear = CAST(Right(DeliveryYear,2)AS INT)
+            , 'Co-invested Employer' AS ValueType
             , SUM([Amount]) AS Value
+            , ValueTypeSort = 4
          FROM [Data_Pub].[DAS_Payments]
-       WHERE Flag_latest = 1 and FundingSource = 'CoInvestedEmployer'
-       GROUP BY
-              [DeliveryMonthShortNameYear], DeliveryMonth
-              , CAST(Right(DeliveryYear,2)AS INT)
+        WHERE Flag_latest = 1
+          AND FundingSource = 'CoInvestedEmployer'
+     GROUP BY
+              [DeliveryMonthShortNameYear]
+            , DeliveryMonth
+            , CAST(Right(DeliveryYear,2)AS INT)
 UNION ALL
-SELECT
+       SELECT
               [DeliveryMonthShortNameYear] AS CalendarMonthShortNameYear
-              , DeliveryMonth
-              , DeliveryYear = CAST(Right(DeliveryYear,2)AS INT)
-            , 'CoInvestedSfa' AS ValueType
+            , DeliveryMonth
+            , DeliveryYear = CAST(Right(DeliveryYear,2)AS INT)
+            , 'Co-invested SFA' AS ValueType
             , SUM([Amount]) AS Value
+            , ValueTypeSort = 5
          FROM [Data_Pub].[DAS_Payments]
-       WHERE Flag_latest = 1 and FundingSource = 'CoInvestedSfa'
-       GROUP BY
-              [DeliveryMonthShortNameYear], DeliveryMonth
-              , CAST(Right(DeliveryYear,2)AS INT);
+        WHERE Flag_latest = 1
+          AND FundingSource = 'CoInvestedSfa'
+     GROUP BY
+              [DeliveryMonthShortNameYear]
+            , DeliveryMonth
+            , CAST(Right(DeliveryYear,2)AS INT);
 GO


### PR DESCRIPTION
This is needed to support the Birst reporting.

I've also tidied up the formatting and alignment.

To see a less noisy diff:

https://github.com/SkillsFundingAgency/das-data/compare/add-sort-order-to-levy-balance-view?expand=1&w=1