### PR TITLE
Run levy declaration snapshot proc at the end of HMRC_Load, and add a…

### DIFF
--- a/src/SFA.DAS.Data.Database/StoredProcedures/LevySnapshot.sql
+++ b/src/SFA.DAS.Data.Database/StoredProcedures/LevySnapshot.sql
@@ -1,8 +1,15 @@
 ﻿CREATE PROCEDURE [Data_Load].[LevySnapshot]
 AS
 	DECLARE @Sql nvarchar(500);
+	DECLARE @TableName nvarchar(100);
+
+	SET @TableName = '[Data_Load].[DAS_LevyDeclarations_Snapshot_' + CONVERT(VARCHAR(10), GETDATE(), 112) +']'
+	
+	IF OBJECT_ID(@TableName, N'U') IS NOT NULL
+		EXEC('DROP TABLE ' + @TableName)
+
 	SET @Sql = 'SELECT *
-		INTO [Data_Load].[DAS_LevyDeclarations_Snapshot_'+CONVERT(VARCHAR(10), GETDATE(), 112) +']
+		INTO ' + @TableName + '
 		FROM [Data_Load].[DAS_LevyDeclarations]'
 
 	EXEC(@Sql)

--- a/src/SFA.DAS.Data.Database/StoredProcedures/Load_Data.sql
+++ b/src/SFA.DAS.Data.Database/StoredProcedures/Load_Data.sql
@@ -673,6 +673,11 @@ BEGIN
 				   (ProcessEventName, ProcessEventDescription, SourceFile_ID)
 			VALUES ('No Source File ID to load', 'No records loaded', -9999999999999)
 		END
+
+		EXEC [Data_Load].[LevySnapshot]
+		INSERT INTO [HMRC].[Process_Log]
+				(ProcessEventName, ProcessEventDescription, SourceFile_ID)
+		VALUES ('Created Levy Snapshot', '', ISNULL(@BISourceFile_ID, -9999999999999))
 	END TRY
 	BEGIN CATCH
 		IF CURSOR_STATUS('local','StringTestConfig')>=-1


### PR DESCRIPTION
Run levy declaration snapshot proc at the end of HMRC_Load, and add an entry to Process_Log when done.
Make levy declarations snapshot.proc re-runnable by dropping the target table if it exists.